### PR TITLE
Update G2Explorer.py

### DIFF
--- a/G2Explorer.py
+++ b/G2Explorer.py
@@ -4287,8 +4287,8 @@ class G2CmdShell(cmd.Cmd):
         record2json = dictKeysUpper(jsonData[1])
 
         # use the test data source and entity type
-        record1json['TRUSTED_ID_NUMBER'] = 'SCORE_TEST'
-        record2json['TRUSTED_ID_NUMBER'] = 'SCORE_TEST'
+        record1json['RECORD_TYPE'] = 'SCORE_TEST'
+        record2json['RECORD_TYPE'] = 'SCORE_TEST'
 
         # add the records
         try:


### PR DESCRIPTION
TRUSTED_ID doesn't really make sense for whyRecords compares.  Switchng to RECORD_TYPE will prevent any cross merging if a user employees RECORD_TYPE on their other data.